### PR TITLE
Adds a check for an empty response to FindById()'s scanJob

### DIFF
--- a/job.go
+++ b/job.go
@@ -11,6 +11,8 @@ import (
 	"time"
 )
 
+var ErrJobNotFound = errors.New("Job not found")
+
 // Job represents a discrete piece of work to be done by a worker.
 type Job struct {
 	id       string
@@ -258,7 +260,7 @@ func scanJob(reply interface{}, job *Job) error {
 	if err != nil {
 		return err
 	} else if len(fields) == 0 {
-		return errors.New("jobs: In scanJob: Job not found")
+		return ErrJobNotFound
 	} else if len(fields)%2 != 0 {
 		return fmt.Errorf("jobs: In scanJob: Expected length of fields to be even but got: %d", len(fields))
 	}

--- a/job.go
+++ b/job.go
@@ -5,6 +5,7 @@
 package jobs
 
 import (
+	"errors"
 	"fmt"
 	"github.com/garyburd/redigo/redis"
 	"time"
@@ -256,8 +257,9 @@ func scanJob(reply interface{}, job *Job) error {
 	fields, err := redis.Values(reply, nil)
 	if err != nil {
 		return err
-	}
-	if len(fields)%2 != 0 {
+	} else if len(fields) == 0 {
+		return errors.New("jobs: In scanJob: Job not found")
+	} else if len(fields)%2 != 0 {
 		return fmt.Errorf("jobs: In scanJob: Expected length of fields to be even but got: %d", len(fields))
 	}
 	for i := 0; i < len(fields)-1; i += 2 {


### PR DESCRIPTION
Fixes #18

Note this doesn't seem to fix it for all transactions but it works for `scanJob`. Feel free to close if you want to fix it at a higher level.