### PR TITLE
After-job hook

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -34,7 +34,7 @@ type Pool struct {
 	// and close the jobs channel
 	exit chan bool
 	// afterFunc is a function that gets called after each job.
-	afterFunc *func(*Job)
+	afterFunc func(*Job)
 	// RWMutex is only used during testing when we need to
 	// change some of the fields for the pool after it was started.
 	// NOTE: currently only used in one test (TestStalePoolsArePurged)
@@ -339,7 +339,7 @@ func (p *Pool) removeStaleSelf() error {
 // SetAfterFunc will assign a function that will be executed each time
 // a job is finished.
 func (p *Pool) SetAfterFunc(f func(*Job)) {
-	*p.afterFunc = f
+	p.afterFunc = f
 }
 
 // Start starts the worker pool. This means the pool will initialize workers,

--- a/worker.go
+++ b/worker.go
@@ -17,7 +17,7 @@ import (
 type worker struct {
 	jobs      chan *Job
 	wg        *sync.WaitGroup
-	afterFunc *func(*Job)
+	afterFunc func(*Job)
 }
 
 // start starts a goroutine in which the worker will continuously
@@ -35,7 +35,7 @@ func (w *worker) start() {
 // the job appropriately depending on the outcome of the execution.
 func (w *worker) doJob(job *Job) {
 	if w.afterFunc != nil {
-		defer (*w.afterFunc)(job)
+		defer w.afterFunc(job)
 	}
 
 	defer func() {

--- a/worker.go
+++ b/worker.go
@@ -15,8 +15,9 @@ import (
 // The jobs chan is shared between all jobs. To stop the worker,
 // simply close the jobs channel.
 type worker struct {
-	jobs chan *Job
-	wg   *sync.WaitGroup
+	jobs      chan *Job
+	wg        *sync.WaitGroup
+	afterFunc *func(*Job)
 }
 
 // start starts a goroutine in which the worker will continuously
@@ -33,6 +34,10 @@ func (w *worker) start() {
 // doJob executes the given job. It also sets the status and timestamps for
 // the job appropriately depending on the outcome of the execution.
 func (w *worker) doJob(job *Job) {
+	if w.afterFunc != nil {
+		defer (*w.afterFunc)(job)
+	}
+
 	defer func() {
 		if r := recover(); r != nil {
 			// Get a reasonable error message from the panic
@@ -76,6 +81,9 @@ func (w *worker) doJob(job *Job) {
 	// Call the handler using the arguments we just instantiated
 	handlerVal := reflect.ValueOf(job.typ.handler)
 	returnVals := handlerVal.Call(handlerArgs)
+	// Set the finished timestamp
+	job.finished = time.Now().UTC().UnixNano()
+
 	// Check if the error return value was nil
 	if !returnVals[0].IsNil() {
 		err := returnVals[0].Interface().(error)
@@ -85,8 +93,6 @@ func (w *worker) doJob(job *Job) {
 		}
 		return
 	}
-	// Set the finished timestamp
-	job.finished = time.Now().UTC().UnixNano()
 	t1 := newTransaction()
 	t1.setJobField(job, "finished", job.finished)
 	if job.IsRecurring() {


### PR DESCRIPTION
This PR adds a function to the pool that gets executed each time a job is finished. Such function can be useful for monitoring.

I thought about adding a full-fledged middleware chains first, but it would add a lot of complexity without too many benefits. This implementation gets a function which can accept a Job via (Pool).SetAfterFunc() and runs it each time a job is finished regardless of its status, passing the job to the function.

Also, I moved the job.finished assgnment before the error checks (worker.go:85); this way the timings are saved even when the job returned an error.

(resubmitted, previous PR: #29)